### PR TITLE
Restore old gradient styles

### DIFF
--- a/src/app/NewsLetterSubscribe.tsx
+++ b/src/app/NewsLetterSubscribe.tsx
@@ -64,7 +64,7 @@ export default function NewsLetterSubscribe() {
               type="submit"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
-              className="px-6 sm:px-8 py-3 sm:py-4 bg-gradient-to-r from-[#EC57AE]/50 via-[#A163B8]/50 to-[#4E59A7]/50 text-white/70 rounded-full font-semibold backdrop-blur-md border border-white/20 hover:opacity-90 transition-all duration-300 whitespace-nowrap"
+              className="px-6 sm:px-8 py-3 sm:py-4 bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-full font-semibold hover:from-purple-600 hover:to-pink-600 transition-all duration-300 shadow-lg hover:shadow-xl whitespace-nowrap"
             >
               Subscribe
             </motion.button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -131,26 +131,21 @@ export default function ComingSoon() {
           animate={{ opacity: 1, y: 0 }}
           transition={{
             duration: 0.8,
-            ease: [0.23, 1, 0.32, 1], // cubic-bezier for bounce-in
+            ease: [0.23, 1, 0.32, 1],
             delay: 0.4
           }}
-          className="text-5xl sm:text-6xl md:text-8xl font-bold mb-6 tracking-tight"
+          className="text-5xl sm:text-6xl md:text-8xl font-bold mb-6 tracking-tight text-white"
           style={{
             fontFamily: 'Maragsa, sans-serif',
-            background:
-              'linear-gradient(135deg, #44486D 0%, #4E59A7 35%, #A163B8 70%, #EC57AE 100%)',
-            backgroundClip: 'text',
-            WebkitBackgroundClip: 'text',
-            color: 'transparent',
-            WebkitTextFillColor: 'transparent',
-            textShadow: '0 0 15px rgba(236,87,174,0.4)',
             lineHeight: '1.2',
             paddingTop: '0.5em',
-            paddingBottom: '0.5em',
-            overflow: 'visible'
+            paddingBottom: '0.5em'
           }}
         >
-          Coming&nbsp;Soon
+          Coming
+          <span className="block bg-gradient-to-r from-purple-400 via-pink-400 to-indigo-400 bg-clip-text text-transparent">
+            Soon
+          </span>
         </motion.h1>
 
 


### PR DESCRIPTION
## Summary
- revert hero heading gradient to earlier look
- update newsletter subscribe button to previous colors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a33209fc083319cfd242b9f5a86f3