### PR TITLE
Restore inline heading and add footer spacing

### DIFF
--- a/src/app/NewsLetterSubscribe.tsx
+++ b/src/app/NewsLetterSubscribe.tsx
@@ -64,7 +64,7 @@ export default function NewsLetterSubscribe() {
               type="submit"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
-              className="px-6 sm:px-8 py-3 sm:py-4 bg-gradient-to-r from-[#EC57AE]/50 via-[#A163B8]/50 to-[#4E59A7]/50 text-white/70 rounded-full font-semibold backdrop-blur-md border border-white/20 hover:opacity-90 transition-all duration-300 whitespace-nowrap"
+              className="px-6 sm:px-8 py-3 sm:py-4 bg-gradient-to-r from-[#EC57AE]/70 via-[#A163B8]/70 to-[#4E59A7]/70 text-white rounded-full font-semibold backdrop-blur-md border border-white/30 hover:opacity-90 transition-all duration-300 shadow-lg hover:shadow-xl whitespace-nowrap"
             >
               Subscribe
             </motion.button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -174,7 +174,7 @@ export default function ComingSoon() {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: 2, duration: 0.8 }}
-          className="mt-16 flex space-x-6"
+          className="mt-16 mb-20 flex space-x-6"
         >
           {/* Mail */}
           <motion.a


### PR DESCRIPTION
## Summary
- revert the split gradient heading
- return newsletter button to earlier gradient
- add margin below contact icons so footer doesn't overlap

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a33209fc083319cfd242b9f5a86f3